### PR TITLE
Adds query parameter functionality for easier sharing. 

### DIFF
--- a/comparar/templates/index.html
+++ b/comparar/templates/index.html
@@ -110,7 +110,7 @@
       <strong>disruptive.</strong>
     </em> -->
 
-    <p class="row top-buffer"> Angellist notes {{ stats.results|get_winner_item:"Angel List" }} startups related to
+    <p class="row top-buffer"> Angel List notes {{ stats.results|get_winner_item:"Angel List" }} startups related to
       <strong>{{winner}}</strong>, versus {{ stats.results|get_loser_item:"Angel List" }} for
       <strong>{{loser}}</strong>.
     </p>
@@ -139,7 +139,7 @@
 
   {% elif status == 'fail' %}
     <h1>
-      try again :(
+      try again! {{failure_description}}
     </h1>
 
   {% endif %}


### PR DESCRIPTION
Also changes "Angellist" to "Angel List" and adds failure descriptions in case of error.

Entering a URL like `comparar.biz?left=marxism&right=capitalism` renders that comparison. You can copy and paste that link and send it to friends. So now, when you enter fields into the form, it immediately redirects to a GET request with `left` and `right` query parameters.

Only proceeds if both parameters are present. If one or the other is missing, we display an error message.
